### PR TITLE
Bugfix/fix latest forge crash (#16)

### DIFF
--- a/src/main/java/shadows/toaster/ToastControl.java
+++ b/src/main/java/shadows/toaster/ToastControl.java
@@ -30,17 +30,27 @@ public class ToastControl {
 	public static final ResourceLocation ORIGINAL = new ResourceLocation("textures/gui/toasts.png");
 
 	@SubscribeEvent
-	public void keys(KeyInputEvent e) {
-		if (CLEAR.isKeyDown() && CLEAR.isPressed()) Minecraft.getInstance().getToastGui().clear();
-	}
-
-	@SubscribeEvent
 	public void preInit(FMLClientSetupEvent e) {
 		Minecraft.getInstance().toastGui = new BetterGuiToast();
-		MinecraftForge.EVENT_BUS.register(this);
+		registerEventBusListeners();
 		handleToastReloc();
 		handleBlockedClasses();
 		ClientRegistry.registerKeyBinding(CLEAR);
+	}
+
+	private void registerEventBusListeners() {
+		MinecraftForge.EVENT_BUS.register(new Object(){
+			@SubscribeEvent
+			public void keys(KeyInputEvent e) {
+				if (CLEAR.isKeyDown() && CLEAR.isPressed()) Minecraft.getInstance().getToastGui().clear();
+			}
+
+			@SubscribeEvent
+			public void clientTick(ClientTickEvent e) {
+				if (e.phase == Phase.END) for (BetterToastInstance<?> t : tracker)
+					t.tick();
+			}
+		});
 	}
 
 	static void handleToastReloc() {
@@ -70,11 +80,4 @@ public class ToastControl {
 	}
 
 	public static List<BetterToastInstance<?>> tracker = new ArrayList<>();
-
-	@SubscribeEvent
-	public void clientTick(ClientTickEvent e) {
-		if (e.phase == Phase.END) for (BetterToastInstance<?> t : tracker)
-			t.tick();
-	}
-
 }

--- a/src/main/java/shadows/toaster/ToastLoader.java
+++ b/src/main/java/shadows/toaster/ToastLoader.java
@@ -21,7 +21,6 @@ public class ToastLoader {
 		if (FMLEnvironment.dist == Dist.CLIENT) {
 			ToastControl mod = new ToastControl();
 			FMLJavaModLoadingContext.get().getModEventBus().register(mod);
-			MinecraftForge.EVENT_BUS.register(mod);
 			MinecraftForge.EVENT_BUS.register(ToastConfig.class);
 			ModLoadingContext.get().registerConfig(ModConfig.Type.COMMON, ToastConfig.SPEC);
 		} else LOGGER.error("Running on a dedicated server, disabling mod.");


### PR DESCRIPTION
This PR fixes a crash as reported in #16 where Forge versions 32.0.96 and above crash with `java.lang.IllegalArgumentException: Method public void shadows.toaster.ToastControl.clientTick(net.minecraftforge.event.TickEvent$ClientTickEvent) has @SubscribeEvent annotation, but takes an argument that is not a subtype of the base type interface net.minecraftforge.fml.event.lifecycle.IModBusEvent`.

`FMLJavaModLoadingContext.get().getModEventBus()` requires all methods decorated with `@SubscribeEvent` to implement `IModBusEvent` which `KeyInputEvent` and `ClientTickEvent` does not implement. Currently, all `@SubscribeEvent` decorated methods are registered on both `getModEventBus()` and `MinecraftForge.EVENT_BUS` which was allowed up until 32.0.96.

To fix this, my PR separates these methods in `ToastControl` that use `KeyInputEvent` and `ClientTickEvent` into an anonymous object, and registers these methods on the `MinecraftForge.EVENT_BUS` independently of the methods intended for `getModEventBus()` (using `FMLClientSetupEvent`).